### PR TITLE
fix(animation-manager): avoid animation is set correctly if fallback …

### DIFF
--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -390,14 +390,9 @@ static StorageAnimation*
     uint32_t whole_weight = 0;
 
     bool fallback = XTREME_SETTINGS()->fallback_anim;
-    FURI_LOG_E(TAG, "test avoid animation: ");
-    FURI_LOG_E(TAG, "%d", dolphin_internal_size);
-    FURI_LOG_E(TAG, "%d", StorageAnimationList_size(animation_list));
-
     bool unlock = XTREME_SETTINGS()->unlock_anims;
 
     uint32_t valid_animations = 0;
-
     for
         M_EACH(item, animation_list, StorageAnimationList_t) {
             const StorageAnimationManifestInfo* manifest_info = animation_storage_get_meta(*item);
@@ -407,14 +402,13 @@ static StorageAnimation*
             };
         }
 
-    FURI_LOG_E(TAG, "valid animations: %ld", valid_animations);
     if(valid_animations <= 2 && !fallback) {
         // One ext anim and fallback disabled, dont skip current anim (current = only ext one)
         avoid_animation = NULL;
-        FURI_LOG_E(TAG, "clear avoid animation");
     }
 
     if(StorageAnimationList_size(animation_list) == dolphin_internal_size + 1 && !fallback) {
+        // One ext anim and fallback disabled, dont skip current anim (current = only ext one)
         avoid_animation = NULL;
     }
 
@@ -425,9 +419,6 @@ static StorageAnimation*
             animation_storage_get_meta(storage_animation);
         bool valid = animation_manager_is_valid_idle_animation(manifest_info, &stats, unlock);
 
-        if(avoid_animation != NULL) {
-            FURI_LOG_E(TAG, avoid_animation);
-        }
         if(avoid_animation != NULL && strcmp(manifest_info->name, avoid_animation) == 0) {
             // Avoid repeating same animation twice
             valid = false;

--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -397,20 +397,22 @@ static StorageAnimation*
     bool unlock = XTREME_SETTINGS()->unlock_anims;
 
     uint32_t valid_animations = 0;
-    /* StorageAnimationList_it_t t;
+    StorageAnimationList_it_t t;
     for(StorageAnimationList_it(t, animation_list); !StorageAnimationList_end_p(t);) {
+        FURI_LOG_E(TAG, "test");
         StorageAnimation* storage_animation = *StorageAnimationList_ref(t);
         const StorageAnimationManifestInfo* manifest_info =
             animation_storage_get_meta(storage_animation);
-
         bool valid = animation_manager_is_valid_idle_animation(manifest_info, &stats, unlock);
+
         if(valid) {
             valid_animations += 1;
         };
-    } */
+        StorageAnimationList_next(t);
+    }
 
     FURI_LOG_E(TAG, "valid animations: %ld", valid_animations);
-    if(valid_animations <= 1 && !fallback) {
+    if(valid_animations <= 2 && !fallback) {
         // One ext anim and fallback disabled, dont skip current anim (current = only ext one)
         avoid_animation = NULL;
         FURI_LOG_E(TAG, "clear avoid animation");

--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -397,19 +397,15 @@ static StorageAnimation*
     bool unlock = XTREME_SETTINGS()->unlock_anims;
 
     uint32_t valid_animations = 0;
-    StorageAnimationList_it_t t;
-    for(StorageAnimationList_it(t, animation_list); !StorageAnimationList_end_p(t);) {
-        FURI_LOG_E(TAG, "test");
-        StorageAnimation* storage_animation = *StorageAnimationList_ref(t);
-        const StorageAnimationManifestInfo* manifest_info =
-            animation_storage_get_meta(storage_animation);
-        bool valid = animation_manager_is_valid_idle_animation(manifest_info, &stats, unlock);
 
-        if(valid) {
-            valid_animations += 1;
-        };
-        StorageAnimationList_next(t);
-    }
+    for
+        M_EACH(item, animation_list, StorageAnimationList_t) {
+            const StorageAnimationManifestInfo* manifest_info = animation_storage_get_meta(*item);
+            bool valid = animation_manager_is_valid_idle_animation(manifest_info, &stats, unlock);
+            if(valid) {
+                valid_animations += 1;
+            };
+        }
 
     FURI_LOG_E(TAG, "valid animations: %ld", valid_animations);
     if(valid_animations <= 2 && !fallback) {

--- a/applications/services/desktop/animations/animation_manager.c
+++ b/applications/services/desktop/animations/animation_manager.c
@@ -392,23 +392,44 @@ static StorageAnimation*
     bool fallback = XTREME_SETTINGS()->fallback_anim;
     FURI_LOG_E(TAG, "test avoid animation: ");
     FURI_LOG_E(TAG, "%d", dolphin_internal_size);
+    FURI_LOG_E(TAG, "%d", StorageAnimationList_size(animation_list));
+
+    bool unlock = XTREME_SETTINGS()->unlock_anims;
+
+    uint32_t valid_animations = 0;
+    /* StorageAnimationList_it_t t;
+    for(StorageAnimationList_it(t, animation_list); !StorageAnimationList_end_p(t);) {
+        StorageAnimation* storage_animation = *StorageAnimationList_ref(t);
+        const StorageAnimationManifestInfo* manifest_info =
+            animation_storage_get_meta(storage_animation);
+
+        bool valid = animation_manager_is_valid_idle_animation(manifest_info, &stats, unlock);
+        if(valid) {
+            valid_animations += 1;
+        };
+    } */
+
+    FURI_LOG_E(TAG, "valid animations: %ld", valid_animations);
+    if(valid_animations <= 1 && !fallback) {
+        // One ext anim and fallback disabled, dont skip current anim (current = only ext one)
+        avoid_animation = NULL;
+        FURI_LOG_E(TAG, "clear avoid animation");
+    }
 
     if(StorageAnimationList_size(animation_list) == dolphin_internal_size + 1 && !fallback) {
-        // One ext anim and fallback disabled, dont skip current anim (current = only ext one)
         avoid_animation = NULL;
     }
 
-    FURI_LOG_E(TAG, "%d", fallback);
-
     StorageAnimationList_it_t it;
-    bool unlock = XTREME_SETTINGS()->unlock_anims;
     for(StorageAnimationList_it(it, animation_list); !StorageAnimationList_end_p(it);) {
         StorageAnimation* storage_animation = *StorageAnimationList_ref(it);
         const StorageAnimationManifestInfo* manifest_info =
             animation_storage_get_meta(storage_animation);
         bool valid = animation_manager_is_valid_idle_animation(manifest_info, &stats, unlock);
 
-        FURI_LOG_E(TAG, avoid_animation);
+        if(avoid_animation != NULL) {
+            FURI_LOG_E(TAG, avoid_animation);
+        }
         if(avoid_animation != NULL && strcmp(manifest_info->name, avoid_animation) == 0) {
             // Avoid repeating same animation twice
             valid = false;


### PR DESCRIPTION
…is enabled and the user has only one or less available animation

# What's new

- [Describe changes here]

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
